### PR TITLE
corrected format-security build error

### DIFF
--- a/stompbox-jack/stompbox-jack.cpp
+++ b/stompbox-jack/stompbox-jack.cpp
@@ -167,8 +167,7 @@ int main(int argc, char* argv[])
         preset_name = argv[1];
     }
 
-    fprintf(stderr, guitarProcessor->GetVersion().c_str());
-    fprintf(stderr, "\n\n");
+    fprintf(stderr, "%s\n\n", guitarProcessor->GetVersion().c_str());
 
     // Old stuff for working with BOSS GT-1 sysex messages
     


### PR DESCRIPTION
stompbox/stompbox-jack/stompbox-jack.cpp:170:12: error: format not a string literal and no format arguments [-Werror=format-security]